### PR TITLE
Initial version of the wrapped submission form

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,0 +1,8 @@
+name: ISIC Challenge Submission
+description: A covalic extension to customize submission creation
+version: 0.1.0
+dependencies:
+    - covalic
+webpack:
+  main:
+    plugin: web_client/main.js

--- a/web_client/main.js
+++ b/web_client/main.js
@@ -1,3 +1,4 @@
+import wrapPhaseView from './wrapPhaseView';
 import wrapSubmitView from './wrapSubmitView';
 
 function load() {
@@ -13,6 +14,10 @@ function load() {
         covalic.views.body.SubmitView,
         covalic.collections.SubmissionCollection,
         covalic.router
+    );
+
+    wrapPhaseView(
+        covalic.views.body.PhaseView
     );
 }
 

--- a/web_client/main.js
+++ b/web_client/main.js
@@ -2,7 +2,6 @@ import wrapSubmitView from './wrapSubmitView';
 
 function load() {
     const covalic = window.covalic;
-    const challengeId = '560d7856cad3a57cfde481ba';
 
     // Install submission wrapper if we are running the covalic
     // app, otherwise this plugin is a noop.
@@ -13,8 +12,7 @@ function load() {
     wrapSubmitView(
         covalic.views.body.SubmitView,
         covalic.collections.SubmissionCollection,
-        covalic.router,
-        challengeId
+        covalic.router
     );
 }
 

--- a/web_client/main.js
+++ b/web_client/main.js
@@ -1,0 +1,21 @@
+import wrapSubmitView from './wrapSubmitView';
+
+function load() {
+    const covalic = window.covalic;
+    const challengeId = '560d7856cad3a57cfde481ba';
+
+    // Install submission wrapper if we are running the covalic
+    // app, otherwise this plugin is a noop.
+    if (!covalic) {
+        return;
+    }
+
+    wrapSubmitView(
+        covalic.views.body.SubmitView,
+        covalic.collections.SubmissionCollection,
+        covalic.router,
+        challengeId
+    );
+}
+
+$(load);

--- a/web_client/stylesheets/submitViewForm.styl
+++ b/web_client/stylesheets/submitViewForm.styl
@@ -1,3 +1,15 @@
-.isic-submission-form-example
-  margin-left 0.5em
-  font-style italic
+.isic-submission-form
+  .isic-submission-form-example
+    margin-left 0.5em
+    font-style italic
+
+  .form-group,.radio-inline,.checkbox
+    margin-bottom 20px
+
+  .checkbox
+    margin-top 0
+
+.isic-section-header
+  font-size 14px
+  font-weight bold
+  margin 0 0 5px

--- a/web_client/stylesheets/submitViewForm.styl
+++ b/web_client/stylesheets/submitViewForm.styl
@@ -9,6 +9,9 @@
   .checkbox
     margin-top 0
 
+  .input-group-btn > button
+    height 34px
+
 .isic-section-header
   font-size 14px
   font-weight bold

--- a/web_client/stylesheets/submitViewForm.styl
+++ b/web_client/stylesheets/submitViewForm.styl
@@ -1,0 +1,3 @@
+.isic-submission-form-example
+  margin-left 0.5em
+  font-style italic

--- a/web_client/stylesheets/submitViewForm.styl
+++ b/web_client/stylesheets/submitViewForm.styl
@@ -3,6 +3,13 @@
     margin-left 0.5em
     font-style italic
 
+  .isic-submission-form-subtext
+    font-size 13px
+    font-style italic
+
+  .isic-submission-form-checkbox-margin
+    margin-left 20px
+
   .form-group,.radio-inline,.checkbox
     margin-bottom 20px
 

--- a/web_client/templates/submitViewForm.pug
+++ b/web_client/templates/submitViewForm.pug
@@ -2,22 +2,22 @@
 .isic-submission-form
   .form-group
     label A brief description of your algorithm’s approach
-    span.isic-submission-form-example e.g. "ResNet ensemble with normalized images"
+    span.isic-submission-form-example e.g. "Quasi-adaptive deep learning with stochastic optimization"
     input.c-submission-approach-input.isic-submission-approach-input.form-control.typeahead(
     type='text', data-provide='typeahead', autocomplete='off', maxlength=maxTextLength, value=approach)
   .form-group
     label Your team's name
-    span.isic-submission-form-example e.g. "RECOD Titans / UNICAMP"
+    span.isic-submission-form-example e.g. "State University Medical Center"
     input.c-submission-organization-input.form-control(
       type='text', maxlength=maxTextLength, value=organization)
   .form-group
     label Website URL for your team
-    span.isic-submission-form-example e.g. "https://recodbr.wordpress.com/"
+    span.isic-submission-form-example e.g. "https://state-u.edu/medical"
     input.c-submission-organization-url-input.form-control(
       type='text', maxlength=maxUrlLength, value=organizationUrl)
   .form-group
     label URL for your arXiv abstract
-    span.isic-submission-form-example e.g. "https://arxiv.org/abs/1703.04819"
+    span.isic-submission-form-example e.g. "https://arxiv.org/abs/1234.12345"
     input.c-submission-documentation-url-input.form-control(
       type='text', maxlength=maxUrlLength, value=documentationUrl)
   h4.isic-section-header External data

--- a/web_client/templates/submitViewForm.pug
+++ b/web_client/templates/submitViewForm.pug
@@ -41,19 +41,23 @@
   h4.isic-section-header External data
   label.radio-inline
     input.isic-submission-external-datasources-input(
-      type='radio', name='c-external-datasources', value='yes', checked=usesExternalData)
+      type='radio', name='c-external-datasources', value='yes', checked=usesExternalData === true)
     | yes
   label.radio-inline
     input.isic-submission-external-datasources-input(
-    type='radio', name='c-external-datasources', value='no', checked=!usesExternalData)
+    type='radio', name='c-external-datasources', value='no', checked=usesExternalData === false)
     | no
   label.radio-inline
-    | Did you use any external data sources?
+    | Did you use any additional skin lesion or dermoscopic datasets to train your algorithm?
+    .isic-submission-form-subtext
+      | This is for categorizing purposes only and will not disqualify your submission
   h4.isic-section-header Data sharing policy
   .checkbox
     label
       input.isic-submission-allow-share-input(type='checkbox')
-      | Do you agree to allow us to share and use your submission for additional research?
+      | We agree to allow this submission to be shared and used for additional research?
+    .isic-submission-form-subtext.isic-submission-form-checkbox-margin
+      | Your agreement is required.
 .c-submission-validation-error
 h4.isic-section-header Upload output files
 .c-submit-upload-widget

--- a/web_client/templates/submitViewForm.pug
+++ b/web_client/templates/submitViewForm.pug
@@ -1,0 +1,37 @@
+.c-submission-mismatch-container
+.form-group
+  label A brief description of your algorithm’s approach
+  span.isic-submission-form-example e.g. "ResNet ensemble with normalized images"
+  input.c-submission-approach-input.isic-submission-approach-input.form-control.typeahead(
+  type='text', data-provide='typeahead', autocomplete='off', maxlength=maxTextLength, value=approach)
+.form-group
+  label Your team's name
+  span.isic-submission-form-example e.g. "RECOD Titans / UNICAMP"
+  input.c-submission-organization-input.form-control(
+    type='text', maxlength=maxTextLength, value=organization)
+.form-group
+  label Website URL for your team
+  span.isic-submission-form-example e.g. "https://recodbr.wordpress.com/"
+  input.c-submission-organization-url-input.form-control(
+    type='text', maxlength=maxUrlLength, value=organizationUrl)
+.form-group
+  label URL for your arXiv abstract
+  span.isic-submission-form-example e.g. "https://arxiv.org/abs/1703.04819"
+  input.isic-submission-arxiv-url-input.form-control(
+    type='text', maxlength=maxUrlLength, value=arxivUrl)
+label.radio-inline
+  input.isic-submission-external-datasources-input(
+    type='radio', name='c-external-datasources', value='yes', checked=usesExternalData)
+  | yes
+label.radio-inline
+  input.isic-submission-external-datasources-input(
+  type='radio', name='c-external-datasources', value='no', checked=!usesExternalData)
+  | no
+label.radio-inline
+  | Did you use any external data sources?
+.checkbox
+  label
+    input.isic-submission-allow-share-input(type='checkbox')
+    | Do you agree to allow us to share and use your submission for additional research?
+.c-submission-validation-error
+.c-submit-upload-widget

--- a/web_client/templates/submitViewForm.pug
+++ b/web_client/templates/submitViewForm.pug
@@ -18,8 +18,8 @@
   .form-group
     label URL for your arXiv abstract
     span.isic-submission-form-example e.g. "https://arxiv.org/abs/1703.04819"
-    input.isic-submission-arxiv-url-input.form-control(
-      type='text', maxlength=maxUrlLength, value=arxivUrl)
+    input.c-submission-documentation-url-input.form-control(
+      type='text', maxlength=maxUrlLength, value=documentationUrl)
   h4.isic-section-header External data
   label.radio-inline
     input.isic-submission-external-datasources-input(

--- a/web_client/templates/submitViewForm.pug
+++ b/web_client/templates/submitViewForm.pug
@@ -3,8 +3,26 @@
   .form-group
     label A brief description of your algorithm’s approach
     span.isic-submission-form-example e.g. "Quasi-adaptive deep learning with stochastic optimization"
-    input.c-submission-approach-input.isic-submission-approach-input.form-control.typeahead(
-    type='text', data-provide='typeahead', autocomplete='off', maxlength=maxTextLength, value=approach)
+    .input-group
+      if createNewApproach
+        input.isic-submission-create-approach-input.form-control(
+          type='text', maxlength=maxTextLength)
+      else
+        select.isic-submission-approach-input.form-control
+          for a in approaches
+            option(value=a, selected=a === approach)
+              = a
+      span.input-group-btn
+        if createNewApproach
+          - var disabled = !approaches.length
+          - var title = 'Use an existing approach';
+          if disabled
+            - title = 'No previous submissions found'
+          button.btn.btn-default.isic-create-new-approach-button(title=title, disabled=disabled)
+            i.icon-cancel
+        else
+          button.btn.btn-default.isic-create-new-approach-button(title='Create a new approach')
+            i.icon-plus
   .form-group
     label Your team's name
     span.isic-submission-form-example e.g. "State University Medical Center"

--- a/web_client/templates/submitViewForm.pug
+++ b/web_client/templates/submitViewForm.pug
@@ -1,37 +1,41 @@
 .c-submission-mismatch-container
-.form-group
-  label A brief description of your algorithm’s approach
-  span.isic-submission-form-example e.g. "ResNet ensemble with normalized images"
-  input.c-submission-approach-input.isic-submission-approach-input.form-control.typeahead(
-  type='text', data-provide='typeahead', autocomplete='off', maxlength=maxTextLength, value=approach)
-.form-group
-  label Your team's name
-  span.isic-submission-form-example e.g. "RECOD Titans / UNICAMP"
-  input.c-submission-organization-input.form-control(
-    type='text', maxlength=maxTextLength, value=organization)
-.form-group
-  label Website URL for your team
-  span.isic-submission-form-example e.g. "https://recodbr.wordpress.com/"
-  input.c-submission-organization-url-input.form-control(
-    type='text', maxlength=maxUrlLength, value=organizationUrl)
-.form-group
-  label URL for your arXiv abstract
-  span.isic-submission-form-example e.g. "https://arxiv.org/abs/1703.04819"
-  input.isic-submission-arxiv-url-input.form-control(
-    type='text', maxlength=maxUrlLength, value=arxivUrl)
-label.radio-inline
-  input.isic-submission-external-datasources-input(
-    type='radio', name='c-external-datasources', value='yes', checked=usesExternalData)
-  | yes
-label.radio-inline
-  input.isic-submission-external-datasources-input(
-  type='radio', name='c-external-datasources', value='no', checked=!usesExternalData)
-  | no
-label.radio-inline
-  | Did you use any external data sources?
-.checkbox
-  label
-    input.isic-submission-allow-share-input(type='checkbox')
-    | Do you agree to allow us to share and use your submission for additional research?
+.isic-submission-form
+  .form-group
+    label A brief description of your algorithm’s approach
+    span.isic-submission-form-example e.g. "ResNet ensemble with normalized images"
+    input.c-submission-approach-input.isic-submission-approach-input.form-control.typeahead(
+    type='text', data-provide='typeahead', autocomplete='off', maxlength=maxTextLength, value=approach)
+  .form-group
+    label Your team's name
+    span.isic-submission-form-example e.g. "RECOD Titans / UNICAMP"
+    input.c-submission-organization-input.form-control(
+      type='text', maxlength=maxTextLength, value=organization)
+  .form-group
+    label Website URL for your team
+    span.isic-submission-form-example e.g. "https://recodbr.wordpress.com/"
+    input.c-submission-organization-url-input.form-control(
+      type='text', maxlength=maxUrlLength, value=organizationUrl)
+  .form-group
+    label URL for your arXiv abstract
+    span.isic-submission-form-example e.g. "https://arxiv.org/abs/1703.04819"
+    input.isic-submission-arxiv-url-input.form-control(
+      type='text', maxlength=maxUrlLength, value=arxivUrl)
+  h4.isic-section-header External data
+  label.radio-inline
+    input.isic-submission-external-datasources-input(
+      type='radio', name='c-external-datasources', value='yes', checked=usesExternalData)
+    | yes
+  label.radio-inline
+    input.isic-submission-external-datasources-input(
+    type='radio', name='c-external-datasources', value='no', checked=!usesExternalData)
+    | no
+  label.radio-inline
+    | Did you use any external data sources?
+  h4.isic-section-header Data sharing policy
+  .checkbox
+    label
+      input.isic-submission-allow-share-input(type='checkbox')
+      | Do you agree to allow us to share and use your submission for additional research?
 .c-submission-validation-error
+h4.isic-section-header Upload output files
 .c-submit-upload-widget

--- a/web_client/wrapPhaseView.js
+++ b/web_client/wrapPhaseView.js
@@ -1,0 +1,20 @@
+import { wrap } from 'girder/utilities/PluginUtils';
+
+export default function (PhaseView) {
+    function shouldWrap(view) {
+        const meta = view.model.get('meta');
+        const isicPhase = meta && meta.isic2018;
+        return isicPhase === 'validation';
+    }
+
+    wrap(PhaseView, 'render', function (render) {
+        if (!shouldWrap(this)) {
+            return render.call(this);
+        }
+        const hideScores = this.model.get('hideScores');
+        this.model.set('hideScores', true);
+        render.call(this);
+        this.model.set('hideScores', hideScores);
+        return this;
+    });
+}

--- a/web_client/wrapSubmitView.js
+++ b/web_client/wrapSubmitView.js
@@ -55,7 +55,7 @@ export default function (SubmitView, SubmissionCollection, router, challengeId) 
             return;
         }
 
-        this.usesExternalData = false;
+        this.usesExternalData = null;
         this.allowShare = false;
         this.createNewApproach = false;
 
@@ -114,6 +114,9 @@ export default function (SubmitView, SubmissionCollection, router, challengeId) 
         } else if (_.isEmpty(this.documentationUrl)) {
             errorText = 'Please enter a URL for your arxiv abstract.';
             valid = false;
+        } else if (!_.isBoolean(this.usesExternalData)) {
+            errorText = 'You must answer whether or not you used any external data sources.';
+            valid = false;
         } else if (!this.$('.isic-submission-allow-share-input').prop('checked')) {
             errorText = 'You must agree to the data sharing policy before submitting.';
             valid = false;
@@ -169,8 +172,10 @@ export default function (SubmitView, SubmissionCollection, router, challengeId) 
             const val = $(event.currentTarget).val().trim();
             if (val === 'yes') {
                 this.usesExternalData = true;
-            } else {
+            } else if (val === 'no') {
                 this.usesExternalData = false;
+            } else {
+                this.usesExternalData = null;
             }
             this.validateInputs();
         },

--- a/web_client/wrapSubmitView.js
+++ b/web_client/wrapSubmitView.js
@@ -1,0 +1,164 @@
+import _ from 'underscore';
+import { getCurrentUser } from 'girder/auth';
+import { SORT_DESC } from 'girder/constants';
+import { wrap } from 'girder/utilities/PluginUtils';
+
+import submitViewForm from './templates/submitViewForm.pug';
+import './stylesheets/submitViewForm.styl';
+
+const maxTextLength = 80;
+const maxUrlLength = 1024;
+
+export default function (SubmitView, SubmissionCollection, router, challengeId) {
+    function shouldWrap(view) {
+        return view.phase.get('challengeId') === challengeId;
+    }
+
+    function setDefaultsFromApproach(view) {
+        const user = getCurrentUser();
+        if (!user) {
+            return;
+        }
+
+        const params = {
+            userId: user.id,
+            phaseId: view.phase.id,
+            latest: false
+        };
+        if (view.approach) {
+            params.approach = view.approach;
+        }
+
+        const submissions = new SubmissionCollection();
+        submissions.pageLimit = 1;
+        submissions.sortField = 'created';
+        submissions.sortDir = SORT_DESC;
+        submissions.fetch(params).done(() => {
+            if (!submissions.length) {
+                return;
+            }
+            const submission = submissions.at(0);
+            const meta = submission.get('meta') || {};
+            view.approach = submission.get('approach');
+            view.organization = submission.get('organization');
+            view.organizationUrl = submission.get('organizationUrl');
+            view.arxivUrl = meta.arxivUrl;
+            view.usesExternalData = meta.usesExternalData;
+
+            view.render();
+        });
+    }
+
+    wrap(SubmitView, 'initialize', function (initialize) {
+        window.view = this;
+        initialize.apply(this, _.rest(arguments));
+        if (!shouldWrap(this)) {
+            return;
+        }
+
+        this.arxivUrl = '';
+        this.usesExternalData = false;
+
+        setDefaultsFromApproach(this);
+    });
+
+    wrap(SubmitView, 'render', function (render) {
+        render.call(this);
+        if (!shouldWrap(this)) {
+            return this;
+        }
+
+        this.$('.c-submission-approach-input').typeahead('destroy');
+        this.$('.c-submit-uploader-container').html(submitViewForm({
+            maxTextLength,
+            maxUrlLength,
+            approach: this.approach,
+            organization: this.organization,
+            organizationUrl: this.organizationUrl,
+            arxivUrl: this.arxivUrl,
+            usesExternalData: this.usesExternalData
+        }));
+
+        this.uploadWidget.setElement(this.$('.c-submit-upload-widget')).render();
+        this.$('.c-submission-approach-input').typeahead({
+            source: this.approaches,
+            afterSelect: () => {
+                this._updateApproach();
+                setDefaultsFromApproach(this);
+            }
+        });
+
+        return this;
+    });
+
+    wrap(SubmitView, 'validateInputs', function (validateInputs) {
+        if (!shouldWrap(this)) {
+            return validateInputs.call(this);
+        }
+
+        this.$('.c-submission-validation-error').empty();
+
+        var valid = true;
+        var errorText = null;
+
+        if (_.isEmpty(this.approach)) {
+            errorText = 'Please describe your algorithm\'s approach';
+            valid = false;
+        } else if (_.isEmpty(this.organization)) {
+            errorText = 'Please enter an organization or team name.';
+            valid = false;
+        } else if (_.isEmpty(this.organizationUrl)) {
+            errorText = 'Please enter a URL for the organization or team.';
+            valid = false;
+        } else if (_.isEmpty(this.arxivUrl)) {
+            errorText = 'Please enter a URL for your arxiv abstract.';
+            valid = false;
+        } else if (!this.$('.isic-submission-allow-share-input').prop('checked')) {
+            errorText = 'You must agree to the data sharing policy before submitting.';
+            valid = false;
+        }
+
+        if (!valid && this.hasFiles) {
+            this.$('.c-submission-validation-error').text(errorText);
+        }
+
+        var enabled = valid && this.filesCorrect;
+        this.uploadWidget.setUploadEnabled(enabled);
+    });
+
+    wrap(SubmitView, 'uploadFinished', function (uploadFinished) {
+        if (!shouldWrap(this)) {
+            return uploadFinished.call(this);
+        }
+        this.submission.on('c:submissionPosted', function () {
+            router.navigate(`submission/${this.submission.id}`, {trigger: true});
+        }, this).postSubmission({
+            phaseId: this.phase.id,
+            folderId: this.folder.id,
+            title: this.approach,
+            organization: this.organization,
+            organizationUrl: this.organizationUrl,
+            meta: {
+                arxivUrl: this.arxivUrl,
+                usesExternalData: this.usesExternalData
+            },
+            approach: this.approach
+        });
+    });
+
+    Object.assign(SubmitView.prototype.events, {
+        'input .isic-submission-arxiv-url-input': function (event) {
+            this.arxivUrl = $(event.currentTarget).val().trim();
+            this.validateInputs();
+        },
+        'input .isic-submission-external-datasources-input': function (event) {
+            const val = $(event.currentTarget).val().trim();
+            if (val === 'yes') {
+                this.usesExternalData = true;
+            } else {
+                this.usesExternalData = false;
+            }
+            this.validateInputs();
+        }
+    });
+}

--- a/web_client/wrapSubmitView.js
+++ b/web_client/wrapSubmitView.js
@@ -42,7 +42,7 @@ export default function (SubmitView, SubmissionCollection, router, challengeId) 
             view.approach = submission.get('approach');
             view.organization = submission.get('organization');
             view.organizationUrl = submission.get('organizationUrl');
-            view.arxivUrl = meta.arxivUrl;
+            view.documentationUrl = submission.get('documentationUrl');
             view.usesExternalData = meta.usesExternalData;
 
             view.render();
@@ -55,7 +55,6 @@ export default function (SubmitView, SubmissionCollection, router, challengeId) 
             return;
         }
 
-        this.arxivUrl = '';
         this.usesExternalData = false;
         this.allowShare = false;
 
@@ -76,7 +75,7 @@ export default function (SubmitView, SubmissionCollection, router, challengeId) 
             approach: this.approach,
             organization: this.organization,
             organizationUrl: this.organizationUrl,
-            arxivUrl: this.arxivUrl,
+            documentationUrl: this.documentationUrl,
             usesExternalData: this.usesExternalData
         }));
 
@@ -111,7 +110,7 @@ export default function (SubmitView, SubmissionCollection, router, challengeId) 
         } else if (_.isEmpty(this.organizationUrl)) {
             errorText = 'Please enter a URL for the organization or team.';
             valid = false;
-        } else if (_.isEmpty(this.arxivUrl)) {
+        } else if (_.isEmpty(this.documentationUrl)) {
             errorText = 'Please enter a URL for your arxiv abstract.';
             valid = false;
         } else if (!this.$('.isic-submission-allow-share-input').prop('checked')) {
@@ -139,8 +138,8 @@ export default function (SubmitView, SubmissionCollection, router, challengeId) 
             title: this.approach,
             organization: this.organization,
             organizationUrl: this.organizationUrl,
+            documentationUrl: this.documentationUrl,
             meta: {
-                arxivUrl: this.arxivUrl,
                 usesExternalData: this.usesExternalData,
                 agreeToSharingPolicy: this.allowShare
             },
@@ -149,10 +148,6 @@ export default function (SubmitView, SubmissionCollection, router, challengeId) 
     });
 
     Object.assign(SubmitView.prototype.events, {
-        'input .isic-submission-arxiv-url-input': function (event) {
-            this.arxivUrl = $(event.currentTarget).val().trim();
-            this.validateInputs();
-        },
         'input .isic-submission-external-datasources-input': function (event) {
             const val = $(event.currentTarget).val().trim();
             if (val === 'yes') {

--- a/web_client/wrapSubmitView.js
+++ b/web_client/wrapSubmitView.js
@@ -9,9 +9,11 @@ import './stylesheets/submitViewForm.styl';
 const maxTextLength = 80;
 const maxUrlLength = 1024;
 
-export default function (SubmitView, SubmissionCollection, router, challengeId) {
+export default function (SubmitView, SubmissionCollection, router) {
     function shouldWrap(view) {
-        return view.phase.get('challengeId') === challengeId;
+        const meta = view.phase.get('meta');
+        const isicPhase = meta && meta.isic2018;
+        return isicPhase === 'validation' || isicPhase === 'final';
     }
 
     function setDefaultsFromApproach(view) {

--- a/web_client/wrapSubmitView.js
+++ b/web_client/wrapSubmitView.js
@@ -69,6 +69,7 @@ export default function (SubmitView, SubmissionCollection, router, challengeId) 
         }
 
         this.$('.c-submission-approach-input').typeahead('destroy');
+        this.$('.c-submit-page-description').remove();
         this.$('.c-submit-uploader-container').html(submitViewForm({
             maxTextLength,
             maxUrlLength,

--- a/web_client/wrapSubmitView.js
+++ b/web_client/wrapSubmitView.js
@@ -50,7 +50,6 @@ export default function (SubmitView, SubmissionCollection, router, challengeId) 
     }
 
     wrap(SubmitView, 'initialize', function (initialize) {
-        window.view = this;
         initialize.apply(this, _.rest(arguments));
         if (!shouldWrap(this)) {
             return;
@@ -58,6 +57,7 @@ export default function (SubmitView, SubmissionCollection, router, challengeId) 
 
         this.arxivUrl = '';
         this.usesExternalData = false;
+        this.allowShare = false;
 
         setDefaultsFromApproach(this);
     });
@@ -141,7 +141,8 @@ export default function (SubmitView, SubmissionCollection, router, challengeId) 
             organizationUrl: this.organizationUrl,
             meta: {
                 arxivUrl: this.arxivUrl,
-                usesExternalData: this.usesExternalData
+                usesExternalData: this.usesExternalData,
+                agreeToSharingPolicy: this.allowShare
             },
             approach: this.approach
         });
@@ -159,6 +160,10 @@ export default function (SubmitView, SubmissionCollection, router, challengeId) 
             } else {
                 this.usesExternalData = false;
             }
+            this.validateInputs();
+        },
+        'input .isic-submission-allow-share-input': function (event) {
+            this.allowShare = $(event.currentTarget).prop('checked');
             this.validateInputs();
         }
     });

--- a/web_client/wrapSubmitView.js
+++ b/web_client/wrapSubmitView.js
@@ -57,6 +57,7 @@ export default function (SubmitView, SubmissionCollection, router, challengeId) 
 
         this.usesExternalData = false;
         this.allowShare = false;
+        this.createNewApproach = false;
 
         setDefaultsFromApproach(this);
     });
@@ -67,12 +68,18 @@ export default function (SubmitView, SubmissionCollection, router, challengeId) 
             return this;
         }
 
+        const approaches = _.filter(this.approaches, (approach) => approach !== 'default');
+        if (!approaches.length) {
+            this.createNewApproach = true;
+        }
         this.$('.c-submission-approach-input').typeahead('destroy');
         this.$('.c-submit-page-description').remove();
         this.$('.c-submit-uploader-container').html(submitViewForm({
             maxTextLength,
             maxUrlLength,
             approach: this.approach,
+            approaches,
+            createNewApproach: this.createNewApproach,
             organization: this.organization,
             organizationUrl: this.organizationUrl,
             documentationUrl: this.documentationUrl,
@@ -80,13 +87,7 @@ export default function (SubmitView, SubmissionCollection, router, challengeId) 
         }));
 
         this.uploadWidget.setElement(this.$('.c-submit-upload-widget')).render();
-        this.$('.c-submission-approach-input').typeahead({
-            source: this.approaches,
-            afterSelect: () => {
-                this._updateApproach();
-                setDefaultsFromApproach(this);
-            }
-        });
+        this.$('.c-submit-upload-widget .g-start-upload').text('Submit');
 
         return this;
     });
@@ -148,6 +149,22 @@ export default function (SubmitView, SubmissionCollection, router, challengeId) 
     });
 
     Object.assign(SubmitView.prototype.events, {
+        'click .isic-create-new-approach-button': function (event) {
+            this.createNewApproach = !this.createNewApproach;
+            this.approach = '';
+            if (!this.createNewApproach && this.approaches.length) {
+                this.approach = this.approaches[0];
+            }
+            this.render();
+        },
+        'change .isic-submission-approach-input': function (event) {
+            this.approach = $(event.currentTarget).val();
+            setDefaultsFromApproach(this);
+        },
+        'input .isic-submission-create-approach-input': function (event) {
+            this.approach = $(event.currentTarget).val().trim();
+            this.validateInputs();
+        },
         'input .isic-submission-external-datasources-input': function (event) {
             const val = $(event.currentTarget).val().trim();
             if (val === 'yes') {


### PR DESCRIPTION
@brianhelba @msmolens This is a (mostly) complete implementation of the custom form for ISIC.

Right now, the `challengeId` is hard coded to the one I am testing with locally.  We can either change it to the real `challengeId` once it's created, or I can do something like add metadata to a challenge that would determine if it is wrapped by this plugin or not.

I haven't changed the description above the form, but it will be easy to do as well.

![test](https://user-images.githubusercontent.com/31890/41601035-64dfe352-73a5-11e8-8129-ddeebcd02312.png)
