### PR TITLE
Respect phase submission options

### DIFF
--- a/web_client/templates/submitViewForm.pug
+++ b/web_client/templates/submitViewForm.pug
@@ -23,21 +23,24 @@
         else
           button.btn.btn-default.isic-create-new-approach-button(title='Create a new approach')
             i.icon-plus
-  .form-group
-    label Your team's name
-    span.isic-submission-form-example e.g. "State University Medical Center"
-    input.c-submission-organization-input.form-control(
-      type='text', maxlength=maxTextLength, value=organization)
-  .form-group
-    label Website URL for your team
-    span.isic-submission-form-example e.g. "https://state-u.edu/medical"
-    input.c-submission-organization-url-input.form-control(
-      type='text', maxlength=maxUrlLength, value=organizationUrl)
-  .form-group
-    label URL for your arXiv abstract
-    span.isic-submission-form-example e.g. "https://arxiv.org/abs/1234.12345"
-    input.c-submission-documentation-url-input.form-control(
-      type='text', maxlength=maxUrlLength, value=documentationUrl)
+  if phase.enableOrganization()
+    .form-group
+      label Your team's name
+      span.isic-submission-form-example e.g. "State University Medical Center"
+      input.c-submission-organization-input.form-control(
+        type='text', maxlength=maxTextLength, value=organization)
+  if phase.enableOrganizationUrl()
+    .form-group
+      label Website URL for your team
+      span.isic-submission-form-example e.g. "https://state-u.edu/medical"
+      input.c-submission-organization-url-input.form-control(
+        type='text', maxlength=maxUrlLength, value=organizationUrl)
+  if phase.enableDocumentationUrl()
+    .form-group
+      label URL for your arXiv abstract
+      span.isic-submission-form-example e.g. "https://arxiv.org/abs/1234.12345"
+      input.c-submission-documentation-url-input.form-control(
+        type='text', maxlength=maxUrlLength, value=documentationUrl)
   h4.isic-section-header External data
   label.radio-inline
     input.isic-submission-external-datasources-input(

--- a/web_client/wrapSubmitView.js
+++ b/web_client/wrapSubmitView.js
@@ -79,6 +79,7 @@ export default function (SubmitView, SubmissionCollection, router) {
         this.$('.c-submit-uploader-container').html(submitViewForm({
             maxTextLength,
             maxUrlLength,
+            phase: this.phase,
             approach: this.approach,
             approaches,
             createNewApproach: this.createNewApproach,
@@ -107,13 +108,13 @@ export default function (SubmitView, SubmissionCollection, router) {
         if (_.isEmpty(this.approach)) {
             errorText = 'Please describe your algorithm\'s approach';
             valid = false;
-        } else if (_.isEmpty(this.organization)) {
+        } else if (this.phase.enableOrganization() && this.phase.requireOrganization() && _.isEmpty(this.organization)) {
             errorText = 'Please enter an organization or team name.';
             valid = false;
-        } else if (_.isEmpty(this.organizationUrl)) {
+        } else if (this.phase.enableOrganizationUrl() && this.phase.requireOrganizationUrl() && _.isEmpty(this.organizationUrl)) {
             errorText = 'Please enter a URL for the organization or team.';
             valid = false;
-        } else if (_.isEmpty(this.documentationUrl)) {
+        } else if (this.phase.enableDocumentationUrl() && this.phase.requireDocumentationUrl() && _.isEmpty(this.documentationUrl)) {
             errorText = 'Please enter a URL for your arxiv abstract.';
             valid = false;
         } else if (!_.isBoolean(this.usesExternalData)) {


### PR DESCRIPTION
Respect phase submission options in the wrapped submission form. This enables hiding the organization, organization URL, or documentation URL fields using the standard phase options.

In particular, this change will enable hiding the documentation URL field for validation phases. Typically, the documentation isn't published before the final test submission.