### PR TITLE
Enforce the three approach per phase limit on the submission form

### DIFF
--- a/web_client/templates/submitViewForm.pug
+++ b/web_client/templates/submitViewForm.pug
@@ -21,8 +21,14 @@
           button.btn.btn-default.isic-create-new-approach-button(title=title, disabled=disabled)
             i.icon-cancel
         else
-          button.btn.btn-default.isic-create-new-approach-button(title='Create a new approach')
+          - var hasMaxApproaches = approaches.length >= 3;
+          - var title = hasMaxApproaches ? 'Only 3 approaches are allowed per user' : 'Create a new approach';
+          button.btn.btn-default.isic-create-new-approach-button(
+            title=title, disabled=hasMaxApproaches)
             i.icon-plus
+    span.isic-submission-form-subtext
+      | Users may create up to three approaches per phase.  To delete or rename a previous approach, please
+      | #[a(href='https://forum.isic-archive.com/t/how-to-send-a-private-message-to-challenge-organizers/346') contact the Challenge organizers].
   if phase.enableOrganization()
     .form-group
       label Your team's name

--- a/web_client/templates/submitViewForm.pug
+++ b/web_client/templates/submitViewForm.pug
@@ -28,7 +28,7 @@
             i.icon-plus
     if maxApproaches
       span.isic-submission-form-subtext
-        | Users may create up to three approaches per phase.  To delete or rename a previous approach, please
+        | You may submit up to three approaches per task.  To delete or rename a previous approach, please
         | #[a(href='https://forum.isic-archive.com/t/how-to-send-a-private-message-to-challenge-organizers/346') contact the Challenge organizers].
   if phase.enableOrganization()
     .form-group

--- a/web_client/templates/submitViewForm.pug
+++ b/web_client/templates/submitViewForm.pug
@@ -21,14 +21,15 @@
           button.btn.btn-default.isic-create-new-approach-button(title=title, disabled=disabled)
             i.icon-cancel
         else
-          - var hasMaxApproaches = approaches.length >= 3;
+          - var hasMaxApproaches = !!maxApproaches && approaches.length >= maxApproaches;
           - var title = hasMaxApproaches ? 'Only 3 approaches are allowed per user' : 'Create a new approach';
           button.btn.btn-default.isic-create-new-approach-button(
             title=title, disabled=hasMaxApproaches)
             i.icon-plus
-    span.isic-submission-form-subtext
-      | Users may create up to three approaches per phase.  To delete or rename a previous approach, please
-      | #[a(href='https://forum.isic-archive.com/t/how-to-send-a-private-message-to-challenge-organizers/346') contact the Challenge organizers].
+    if maxApproaches
+      span.isic-submission-form-subtext
+        | Users may create up to three approaches per phase.  To delete or rename a previous approach, please
+        | #[a(href='https://forum.isic-archive.com/t/how-to-send-a-private-message-to-challenge-organizers/346') contact the Challenge organizers].
   if phase.enableOrganization()
     .form-group
       label Your team's name

--- a/web_client/wrapSubmitView.js
+++ b/web_client/wrapSubmitView.js
@@ -78,7 +78,10 @@ export default function (SubmitView, SubmissionCollection, router) {
         const maxApproaches = getIsicPhase(this) === 'final' ? 3 : 0;
         if (!approaches.length) {
             this.createNewApproach = true;
+        } else if (maxApproaches && approaches.length >= maxApproaches) {
+            this.createNewApproach = false;
         }
+
         this.$('.c-submission-approach-input').typeahead('destroy');
         this.$('.c-submit-page-description').remove();
         this.$('.c-submit-uploader-container').html(submitViewForm({

--- a/web_client/wrapSubmitView.js
+++ b/web_client/wrapSubmitView.js
@@ -10,9 +10,13 @@ const maxTextLength = 80;
 const maxUrlLength = 1024;
 
 export default function (SubmitView, SubmissionCollection, router) {
-    function shouldWrap(view) {
+    function getIsicPhase(view) {
         const meta = view.phase.get('meta');
-        const isicPhase = meta && meta.isic2018;
+        return meta && meta.isic2018;
+    }
+
+    function shouldWrap(view) {
+        const isicPhase = getIsicPhase(view);
         return isicPhase === 'validation' || isicPhase === 'final';
     }
 
@@ -71,6 +75,7 @@ export default function (SubmitView, SubmissionCollection, router) {
         }
 
         const approaches = _.filter(this.approaches, (approach) => approach !== 'default');
+        const maxApproaches = getIsicPhase(this) === 'final' ? 3 : 0;
         if (!approaches.length) {
             this.createNewApproach = true;
         }
@@ -79,6 +84,7 @@ export default function (SubmitView, SubmissionCollection, router) {
         this.$('.c-submit-uploader-container').html(submitViewForm({
             maxTextLength,
             maxUrlLength,
+            maxApproaches,
             phase: this.phase,
             approach: this.approach,
             approaches,


### PR DESCRIPTION
This is pretty straightforward... just added some text and disabled the "create new approach" button when there are more than two existing approaches.

![test](https://user-images.githubusercontent.com/31890/42779116-6d78dd98-890d-11e8-9251-f2fab4e64df5.png)
