### PR TITLE
Add a note about including a PDF file during the final phase

### DIFF
--- a/web_client/stylesheets/submitViewForm.styl
+++ b/web_client/stylesheets/submitViewForm.styl
@@ -23,3 +23,6 @@
   font-size 14px
   font-weight bold
   margin 0 0 5px
+
+.isic-text-underline
+  text-decoration underline

--- a/web_client/templates/submitViewForm.pug
+++ b/web_client/templates/submitViewForm.pug
@@ -69,8 +69,12 @@
     .isic-submission-form-subtext.isic-submission-form-checkbox-margin
       | Your agreement is required.
 .c-submission-validation-error
-h4.isic-section-header Upload output files
+h4.isic-section-header Upload ZIP file
 if requiresPDFFile
+  span.
+      Upload a ZIP file that contains both your prediction files and an abstract as a PDF document.
+      Submissions that don't contain a PDF file will #[span.isic-text-underline not] be scored.
+else
   span
-    | *You must include an abstract in your submission as a PDF document.  Submissions not containing a PDF file will #[span.isic-text-underline not] be scored.
+    | Upload a ZIP file that contains your prediction files.
 .c-submit-upload-widget

--- a/web_client/templates/submitViewForm.pug
+++ b/web_client/templates/submitViewForm.pug
@@ -70,4 +70,7 @@
       | Your agreement is required.
 .c-submission-validation-error
 h4.isic-section-header Upload output files
+if requiresPDFFile
+  span
+    | *You must include an abstract in your submission as a PDF document.  Submissions not containing a PDF file will #[span.isic-text-underline not] be scored.
 .c-submit-upload-widget

--- a/web_client/wrapSubmitView.js
+++ b/web_client/wrapSubmitView.js
@@ -113,7 +113,8 @@ export default function (SubmitView, SubmissionCollection, router) {
             organization: this.organization,
             organizationUrl: this.organizationUrl,
             documentationUrl: this.documentationUrl,
-            usesExternalData: this.usesExternalData
+            usesExternalData: this.usesExternalData,
+            requiresPDFFile: getIsicPhase(this) === 'final'
         }));
 
         this.uploadWidget.startUpload = _.wrap(this.uploadWidget.startUpload, (startUpload) => {


### PR DESCRIPTION
We should also disable the documentation URL option for the final phases to remove the input element related to the arXiv URL

This is what it looks like now, I don't know if there is anything we want to do to make it more visible...  Red is kind of already used for validation warnings.
![test](https://user-images.githubusercontent.com/31890/43278319-c1416a94-90d8-11e8-98c0-66bed02af661.png)
