### PR TITLE
Fix downloading large submission files

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -30,6 +30,9 @@ from girder.models.user import User
 from girder.utility.model_importer import ModelImporter
 
 
+READ_SIZE = 4 * 1024 * 1024
+
+
 def _readFile(file):
     """
     Read file data into an in-memory buffer.
@@ -41,7 +44,7 @@ def _readFile(file):
     buffer = io.BytesIO()
     with File().open(file) as fileHandle:
         while True:
-            chunk = fileHandle.read()
+            chunk = fileHandle.read(size=READ_SIZE)
             if not chunk:
                 break
             buffer.write(chunk)


### PR DESCRIPTION
When files exceeded 16 MB a "Read exceeds maximum allowed size" error occurred here:
    https://github.com/girder/girder/blob/9dadcd2f9c48cebf56a7674e5c43af4e990fa546/girder/utility/abstract_assetstore_adapter.py#L77-L78

Explicitly specify a smaller chunk read size.