### PR TITLE
Remove documentation url from the submission form

### DIFF
--- a/web_client/templates/submitViewForm.pug
+++ b/web_client/templates/submitViewForm.pug
@@ -42,12 +42,6 @@
       span.isic-submission-form-example e.g. "https://state-u.edu/medical"
       input.c-submission-organization-url-input.form-control(
         type='text', maxlength=maxUrlLength, value=organizationUrl)
-  if phase.enableDocumentationUrl()
-    .form-group
-      label URL for your arXiv abstract
-      span.isic-submission-form-example e.g. "https://arxiv.org/abs/1234.12345"
-      input.c-submission-documentation-url-input.form-control(
-        type='text', maxlength=maxUrlLength, value=documentationUrl)
   h4.isic-section-header External data
   label.radio-inline
     input.isic-submission-external-datasources-input(

--- a/web_client/wrapSubmitView.js
+++ b/web_client/wrapSubmitView.js
@@ -48,7 +48,6 @@ export default function (SubmitView, SubmissionCollection, router) {
             view.approach = submission.get('approach');
             view.organization = submission.get('organization');
             view.organizationUrl = submission.get('organizationUrl');
-            view.documentationUrl = submission.get('documentationUrl');
             view.usesExternalData = meta.usesExternalData;
 
             view.render();
@@ -112,7 +111,6 @@ export default function (SubmitView, SubmissionCollection, router) {
             createNewApproach: this.createNewApproach,
             organization: this.organization,
             organizationUrl: this.organizationUrl,
-            documentationUrl: this.documentationUrl,
             usesExternalData: this.usesExternalData,
             requiresPDFFile: getIsicPhase(this) === 'final'
         }));
@@ -148,9 +146,6 @@ export default function (SubmitView, SubmissionCollection, router) {
         } else if (this.phase.enableOrganizationUrl() && this.phase.requireOrganizationUrl() && _.isEmpty(this.organizationUrl)) {
             errorText = 'Please enter a URL for the organization or team.';
             valid = false;
-        } else if (this.phase.enableDocumentationUrl() && this.phase.requireDocumentationUrl() && _.isEmpty(this.documentationUrl)) {
-            errorText = 'Please enter a URL for your arxiv abstract.';
-            valid = false;
         } else if (!_.isBoolean(this.usesExternalData)) {
             errorText = 'You must answer whether or not you used any external data sources.';
             valid = false;
@@ -178,7 +173,6 @@ export default function (SubmitView, SubmissionCollection, router) {
             title: this.approach,
             organization: this.organization,
             organizationUrl: this.organizationUrl,
-            documentationUrl: this.documentationUrl,
             meta: {
                 usesExternalData: this.usesExternalData,
                 agreeToSharingPolicy: this.allowShare


### PR DESCRIPTION
This allows us to enable documentation url in the phase settings, but still hide it in the submission form.