### PR TITLE
Set MIME type for PDF file

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -118,7 +118,8 @@ def _savePDF(event):
         name=pdfFileName,
         parentType='folder',
         parent=abstractFolder,
-        user=user
+        user=user,
+        mimeType='application/pdf'
     )
 
     # Set submission documentation URL


### PR DESCRIPTION
Set the proper MIME type for uploaded PDF files. This ensures that browsers open the PDF when downloaded inline.